### PR TITLE
Remove black points in the generated colored point cloud

### DIFF
--- a/src/color_lidar_display.cpp
+++ b/src/color_lidar_display.cpp
@@ -209,11 +209,6 @@ int main(int argc, char **argv) {
                     continue;
                 }
                 
-                // set coordinate for the cloud point
-                cloud->points[i].x = x;
-                cloud->points[i].y = y;
-                cloud->points[i].z = z;
-
                 // set the RGB for the cloud point  
                 int RGB[3] = {0, 0, 0}; 
                 getColor(matrix_in, matrix_out, x, y, z, row, col, color_vector, RGB); 
@@ -221,7 +216,11 @@ int main(int argc, char **argv) {
                 if (RGB[0] == 0 && RGB[1] == 0 && RGB[2] == 0) {  
                     continue;
                 }
-                
+		// set coordinate for the cloud point
+                cloud->points[i].x = x;
+                cloud->points[i].y = y;
+                cloud->points[i].z = z;
+
                 cloud->points[i].r = RGB[0];
                 cloud->points[i].g = RGB[1];
                 cloud->points[i].b = RGB[2];


### PR DESCRIPTION
This code will generate black points if their RGB values are zero as they are only registered in the "cloud" PointCloud, but isn't the intention of the following snippet: ([lines 221-223](https://github.com/Livox-SDK/livox_camera_lidar_calibration/blob/27f9e6c8a1eda3326b7673da418e6d7112559c2f/src/color_lidar_display.cpp#L221-L223))
```
                if (RGB[0] == 0 && RGB[1] == 0 && RGB[2] == 0) {  
                    continue;
                }
```
to exclude the points in the point cloud that has no colour correspondence in order not to visualize it? If my assumption is correct about the real intention, then just setting the xyz coordinates after the condition will fix that small bug.

Thank you very much for your great package, it is really cool and works pretty good, but had some hard time with detecting the corners in the point cloud.